### PR TITLE
Bumping engine into node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ branding:
   icon: zap-off
   color: orange
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'label.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "labeler",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labeler",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Labels issues when they land in a repo.",
   "main": "label.js",
   "scripts": {


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Reviewal for automated PRs**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update those actions to use Node.js 16.

Bumping this action to use NodeJS 16 and bumping it's version to get a new release.